### PR TITLE
fix(isReadOnly): allow or not the modification of textField

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/xpeho_ui.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xpeho_ui.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "xpeho_ui"
+               BuildableName = "xpeho_ui"
+               BlueprintName = "xpeho_ui"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "xpeho_ui"
+            BuildableName = "xpeho_ui"
+            BlueprintName = "xpeho_ui"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ InputText(
     password: Bool,
     submitLabel: SubmitLabel,
     onSubmit: () -> Void,
-    onInput: (String) -> Void
+    onInput: (String) -> Void,
+    isReadOnly: Bool
 )
 
 ```

--- a/Sources/xpeho_ui/Components/InputText.swift
+++ b/Sources/xpeho_ui/Components/InputText.swift
@@ -25,6 +25,7 @@ public struct InputText: View {
     var submitLabel: SubmitLabel
     var onSubmit: () -> Void
     var onInput: (String) -> Void
+    var isReadOnly: Bool
     
     @State private var hidden: Bool = true
     @State private var input: String
@@ -50,6 +51,7 @@ public struct InputText: View {
         inputColor: Color = XPEHO_THEME.CONTENT_COLOR,
         password: Bool = false,
         submitLabel: SubmitLabel = .next,
+        isReadOnly: Bool = false,
         onSubmit: @escaping () -> Void = {},
         onInput: @escaping (String) -> Void = { input in
             debugPrint("The input \(input) is typed")
@@ -67,6 +69,7 @@ public struct InputText: View {
         self.submitLabel = submitLabel
         self.onSubmit = onSubmit
         self.onInput = onInput
+        self.isReadOnly = isReadOnly
         self._input = State(initialValue: defaultInput)
     }
     
@@ -93,22 +96,23 @@ public struct InputText: View {
                         onInput(newValue)
                     }
                     .foregroundStyle(inputColor)
-                } else {
-                    TextField(
-                        "",
-                        text: $input,
-                        onCommit: onSubmit
-                    )
-                    .font(.roboto(.regular, size: CGFloat(inputSize)))
-                    .focused($focused, equals: .show)
-                    #if os(iOS)
-                    .textInputAutocapitalization(.never)
-                    .submitLabel(submitLabel)
-                    #endif
-                    .onChange(of: input) { oldValue, newValue in
-                        onInput(newValue)
-                    }
-                    .foregroundStyle(inputColor)
+                }   else {
+                        TextField(
+                            "",
+                            text: $input,
+                            onCommit: onSubmit
+                        )
+                        .font(.roboto(.regular, size: CGFloat(inputSize)))
+                        .focused($focused, equals: .show)
+                        #if os(iOS)
+                        .textInputAutocapitalization(.never)
+                        .submitLabel(submitLabel)
+                        #endif
+                        .onChange(of: input) { oldValue, newValue in
+                            onInput(newValue)
+                        }
+                        .foregroundStyle(inputColor)
+                        .disabled(isReadOnly)
                 }
                 if (!input.isEmpty && password){
                     passwordSwitcherIcon
@@ -135,6 +139,9 @@ public struct InputText: View {
 
 #Preview {
     InputText(
-        password: true
+        label: "email",
+        defaultInput: "test.example@example.com",
+        password: false,
+        isReadOnly: true
     )
 }


### PR DESCRIPTION
# New change proposal

Thank you for contributing to xpeho_ui.

<!-- Please first describe your change. -->

# Change category

- [ ] Feature
- [X] Fix
- [ ] Documentation
- [ ] Chore

# Description

We need this fix, in association with this [PR](https://github.com/XPEHO/XpeApp/pull/211/files), in order to use the display-only InputText for the profile page or other . An isReadOnly field has been created. To block the interaction of user in the field. 

# Screenshots (if any)

<!-- Add screens to show your changes -->

# Checklist

- [X] I have tested my changes
- [ ] The snapshots tests has been checked
- [ ] The snapshots files has been refreshed if needed
- [ ] The previous tests still works
- [ ] I did not broke anything to ensure reverse compatibility
- [X] root README updated
